### PR TITLE
fix(catalog): lowercase metadata.name

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: cosmic-ext-IronRDP
+  name: cosmic-ext-ironrdp
+  title: cosmic-ext-IronRDP
   description: "Rust implementation of the Microsoft Remote Desktop Protocol (RDP)"
   annotations:
     backstage.io/techdocs-ref: dir:.


### PR DESCRIPTION
Lowercases entity name; preserves PascalCase via title field.